### PR TITLE
Make it faster by doing less checks

### DIFF
--- a/crates/gen-wasmtime/src/lib.rs
+++ b/crates/gen-wasmtime/src/lib.rs
@@ -628,8 +628,7 @@ impl Generator for Wasmtime {
         for (name, func) in needs_functions {
             self.src.push_str(&format!(
                 "
-                    let func = get_func(&mut caller, \"{name}\")?;
-                    let func_{name} = func.typed::<{cvt}>(&caller)?;
+                    let func_{name} = get_func::<_, {cvt}>(&mut caller, \"{name}\")?;
                 ",
                 name = name,
                 cvt = func.cvt(),
@@ -800,7 +799,6 @@ impl Generator for Wasmtime {
             }
             self.src.push_str("pub trait ");
             self.src.push_str(&module_camel);
-            self.src.push_str(": Sized ");
             if is_async {
                 self.src.push_str(" + Send");
             }

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -90,7 +90,10 @@ pub mod rt {
         }
     }
 
-    pub fn get_func<T, Args: WasmParams, Results: WasmResults>(caller: &mut Caller<'_, T>, func: &str) -> anyhow::Result<TypedFunc<Args, Results>> {
+    pub fn get_func<T, Args: WasmParams, Results: WasmResults>(
+        caller: &mut Caller<'_, T>,
+        func: &str,
+    ) -> anyhow::Result<TypedFunc<Args, Results>> {
         let func = caller
             .get_export(func)
             .ok_or_else(|| {
@@ -98,9 +101,7 @@ pub mod rt {
                 anyhow::anyhow!(msg)
             })?
             .into_func()
-            .map(|f| unsafe {
-                TypedFunc::new_unchecked(f)
-            })
+            .map(|f| unsafe { TypedFunc::new_unchecked(f) })
             .ok_or_else(|| {
                 let msg = format!("`{}` export not a function", func);
                 anyhow::anyhow!(msg)

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -90,7 +90,7 @@ pub mod rt {
         }
     }
 
-    pub fn get_func<T>(caller: &mut Caller<'_, T>, func: &str) -> anyhow::Result<Func> {
+    pub fn get_func<T, Args: WasmParams, Results: WasmResults>(caller: &mut Caller<'_, T>, func: &str) -> anyhow::Result<TypedFunc<Args, Results>> {
         let func = caller
             .get_export(func)
             .ok_or_else(|| {
@@ -98,6 +98,9 @@ pub mod rt {
                 anyhow::anyhow!(msg)
             })?
             .into_func()
+            .map(|f| unsafe {
+                TypedFunc::new_unchecked(f)
+            })
             .ok_or_else(|| {
                 let msg = format!("`{}` export not a function", func);
                 anyhow::anyhow!(msg)

--- a/crates/wasmtime/src/region.rs
+++ b/crates/wasmtime/src/region.rs
@@ -53,10 +53,7 @@ impl<'a> BorrowChecker<'a> {
             // * The region `r` we're returning accurately describes the
             //   slice we're returning in wasm linear memory.
             unsafe {
-                std::slice::from_raw_parts(
-                    self.ptr.add(r.start as usize) as *const T,
-                    len as usize,
-                )
+                std::slice::from_raw_parts(self.ptr.add(r.start as usize) as *const T, len as usize)
             },
             r,
         ))

--- a/crates/wasmtime/src/region.rs
+++ b/crates/wasmtime/src/region.rs
@@ -1,19 +1,8 @@
-use crate::rt::RawMem;
 use crate::{Endian, GuestError, Le};
-use std::collections::HashSet;
-use std::convert::TryInto;
 use std::marker;
 use std::mem;
 
-// This is a pretty naive way to account for borrows. This datastructure
-// could be made a lot more efficient with some effort.
 pub struct BorrowChecker<'a> {
-    /// Maps from handle to region borrowed. A HashMap is probably not ideal
-    /// for this but it works. It would be more efficient if we could
-    /// check `is_borrowed` without an O(n) iteration, by organizing borrows
-    /// by an ordering of Region.
-    shared_borrows: HashSet<Region>,
-    mut_borrows: HashSet<Region>,
     _marker: marker::PhantomData<&'a mut [u8]>,
     ptr: *mut u8,
     len: usize,
@@ -33,85 +22,44 @@ impl<'a> BorrowChecker<'a> {
         BorrowChecker {
             ptr: data.as_mut_ptr(),
             len: data.len(),
-            shared_borrows: Default::default(),
-            mut_borrows: Default::default(),
             _marker: marker::PhantomData,
         }
     }
 
     pub fn slice<T: AllBytesValid>(&mut self, ptr: i32, len: i32) -> anyhow::Result<&'a [T]> {
-        let (ret, r) = self.get_slice(ptr, len)?;
+        let (ret, _) = self.get_slice(ptr, len)?;
         // SAFETY: We're promoting the valid lifetime of `ret` from a temporary
         // borrow on `self` to `'a` on this `BorrowChecker`. At the same time
         // we're recording that this is a persistent shared borrow (until this
         // borrow checker is deleted), which disallows future mutable borrows
         // of the same data.
         let ret = unsafe { &*(ret as *const [T]) };
-        self.shared_borrows.insert(r);
-        Ok(ret)
-    }
-
-    pub fn slice_mut<T: AllBytesValid>(
-        &mut self,
-        ptr: i32,
-        len: i32,
-    ) -> anyhow::Result<&'a mut [T]> {
-        let (ret, r) = self.get_slice_mut(ptr, len)?;
-        // SAFETY: see `slice` for how we're extending the lifetime by
-        // recording the borrow here. Note that the `mut_borrows` list is
-        // checked on both shared and mutable borrows in the future since a
-        // mutable borrow can't alias with anything.
-        let ret = unsafe { &mut *(ret as *mut [T]) };
-        self.mut_borrows.insert(r);
         Ok(ret)
     }
 
     fn get_slice<T: AllBytesValid>(&self, ptr: i32, len: i32) -> anyhow::Result<(&[T], Region)> {
         let r = self.region::<T>(ptr, len)?;
-        if self.is_mut_borrowed(r) {
-            Err(to_trap(GuestError::PtrBorrowed(r)))
-        } else {
-            Ok((
-                // SAFETY: invariants to uphold:
-                //
-                // * The lifetime of the input is valid for the lifetime of the
-                //   output. In this case we're threading through the lifetime
-                //   of `&self` to the output.
-                // * The actual output is valid, which is guaranteed with the
-                //   `AllBytesValid` bound.
-                // * We uphold Rust's borrowing guarantees, namely that this
-                //   borrow we're returning isn't overlapping with any mutable
-                //   borrows.
-                // * The region `r` we're returning accurately describes the
-                //   slice we're returning in wasm linear memory.
-                unsafe {
-                    std::slice::from_raw_parts(
-                        self.ptr.add(r.start as usize) as *const T,
-                        len as usize,
-                    )
-                },
-                r,
-            ))
-        }
-    }
-
-    fn get_slice_mut<T>(&mut self, ptr: i32, len: i32) -> anyhow::Result<(&mut [T], Region)> {
-        let r = self.region::<T>(ptr, len)?;
-        if self.is_mut_borrowed(r) || self.is_shared_borrowed(r) {
-            Err(to_trap(GuestError::PtrBorrowed(r)))
-        } else {
-            Ok((
-                // SAFETY: same as `get_slice`, except for that we're threading
-                // through `&mut` properties as well.
-                unsafe {
-                    std::slice::from_raw_parts_mut(
-                        self.ptr.add(r.start as usize) as *mut T,
-                        len as usize,
-                    )
-                },
-                r,
-            ))
-        }
+        Ok((
+            // SAFETY: invariants to uphold:
+            //
+            // * The lifetime of the input is valid for the lifetime of the
+            //   output. In this case we're threading through the lifetime
+            //   of `&self` to the output.
+            // * The actual output is valid, which is guaranteed with the
+            //   `AllBytesValid` bound.
+            // * We uphold Rust's borrowing guarantees, namely that this
+            //   borrow we're returning isn't overlapping with any mutable
+            //   borrows.
+            // * The region `r` we're returning accurately describes the
+            //   slice we're returning in wasm linear memory.
+            unsafe {
+                std::slice::from_raw_parts(
+                    self.ptr.add(r.start as usize) as *const T,
+                    len as usize,
+                )
+            },
+            r,
+        ))
     }
 
     fn region<T>(&self, ptr: i32, len: i32) -> anyhow::Result<Region> {
@@ -143,40 +91,11 @@ impl<'a> BorrowChecker<'a> {
         }
     }
 
-    fn is_shared_borrowed(&self, r: Region) -> bool {
-        self.shared_borrows.iter().any(|b| b.overlaps(r))
-    }
-
-    fn is_mut_borrowed(&self, r: Region) -> bool {
-        self.mut_borrows.iter().any(|b| b.overlaps(r))
-    }
-
     pub fn raw(&self) -> *mut [u8] {
         std::ptr::slice_from_raw_parts_mut(self.ptr, self.len)
     }
-}
 
-impl RawMem for BorrowChecker<'_> {
-    fn store<T: Endian>(&mut self, offset: i32, val: T) -> anyhow::Result<()> {
-        let (slice, _) = self.get_slice_mut::<Le<T>>(offset, 1)?;
-        slice[0].set(val);
-        Ok(())
-    }
-
-    fn store_many<T: Endian>(&mut self, offset: i32, val: &[T]) -> anyhow::Result<()> {
-        let (slice, _) = self.get_slice_mut::<Le<T>>(
-            offset,
-            val.len()
-                .try_into()
-                .map_err(|_| to_trap(GuestError::PtrOverflow))?,
-        )?;
-        for (slot, val) in slice.iter_mut().zip(val) {
-            slot.set(*val);
-        }
-        Ok(())
-    }
-
-    fn load<T: Endian>(&self, offset: i32) -> anyhow::Result<T> {
+    pub fn load<T: Endian>(&self, offset: i32) -> anyhow::Result<T> {
         let (slice, _) = self.get_slice::<Le<T>>(offset, 1)?;
         Ok(slice[0].get())
     }
@@ -225,91 +144,4 @@ tuples! {
 pub struct Region {
     pub start: u32,
     pub len: u32,
-}
-
-impl Region {
-    /// Checks if this `Region` overlaps with `rhs` `Region`.
-    fn overlaps(&self, rhs: Region) -> bool {
-        // Zero-length regions can never overlap!
-        if self.len == 0 || rhs.len == 0 {
-            return false;
-        }
-
-        let self_start = self.start as u64;
-        let self_end = self_start + (self.len - 1) as u64;
-
-        let rhs_start = rhs.start as u64;
-        let rhs_end = rhs_start + (rhs.len - 1) as u64;
-
-        if self_start <= rhs_start {
-            self_end >= rhs_start
-        } else {
-            rhs_end >= self_start
-        }
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn nonoverlapping() {
-        let mut bytes = [0; 100];
-        let mut bc = BorrowChecker::new(&mut bytes);
-        bc.slice::<u8>(0, 10).unwrap();
-        bc.slice::<u8>(10, 10).unwrap();
-
-        let mut bc = BorrowChecker::new(&mut bytes);
-        bc.slice::<u8>(10, 10).unwrap();
-        bc.slice::<u8>(0, 10).unwrap();
-
-        let mut bc = BorrowChecker::new(&mut bytes);
-        bc.slice_mut::<u8>(0, 10).unwrap();
-        bc.slice_mut::<u8>(10, 10).unwrap();
-
-        let mut bc = BorrowChecker::new(&mut bytes);
-        bc.slice_mut::<u8>(10, 10).unwrap();
-        bc.slice_mut::<u8>(0, 10).unwrap();
-    }
-
-    #[test]
-    fn overlapping() {
-        let mut bytes = [0; 100];
-        let mut bc = BorrowChecker::new(&mut bytes);
-        bc.slice::<u8>(0, 10).unwrap();
-        bc.slice_mut::<u8>(9, 10).unwrap_err();
-        bc.slice::<u8>(9, 10).unwrap();
-
-        let mut bc = BorrowChecker::new(&mut bytes);
-        bc.slice::<u8>(0, 10).unwrap();
-        bc.slice_mut::<u8>(2, 5).unwrap_err();
-        bc.slice::<u8>(2, 5).unwrap();
-
-        let mut bc = BorrowChecker::new(&mut bytes);
-        bc.slice::<u8>(9, 10).unwrap();
-        bc.slice_mut::<u8>(0, 10).unwrap_err();
-        bc.slice::<u8>(0, 10).unwrap();
-
-        let mut bc = BorrowChecker::new(&mut bytes);
-        bc.slice::<u8>(2, 5).unwrap();
-        bc.slice_mut::<u8>(0, 10).unwrap_err();
-        bc.slice::<u8>(0, 10).unwrap();
-
-        let mut bc = BorrowChecker::new(&mut bytes);
-        bc.slice::<u8>(2, 5).unwrap();
-        bc.slice::<u8>(10, 5).unwrap();
-        bc.slice::<u8>(15, 5).unwrap();
-        bc.slice_mut::<u8>(0, 10).unwrap_err();
-        bc.slice::<u8>(0, 10).unwrap();
-    }
-
-    #[test]
-    fn zero_length() {
-        let mut bytes = [0; 100];
-        let mut bc = BorrowChecker::new(&mut bytes);
-        bc.slice_mut::<u8>(0, 0).unwrap();
-        bc.slice_mut::<u8>(0, 0).unwrap();
-        bc.slice::<u8>(0, 1).unwrap();
-    }
 }


### PR DESCRIPTION
# why? 

the current impl is pretty slow and there are 2 easy wins: 

- do not type check canonical abi functions every time they need to be called, just assume they are correctly typed
- do not implement the borrow checker, as the current impl does not use mutable borrows anyway